### PR TITLE
Fixed Cypress command in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "ISC",
   "scripts": {
     "start": "grunt dev && node index.js",
-    "cy:open": "npx cypres open"
+    "cy:open": "npx cypress open"
   },
   "browser": {
     "vue": "vue/dist/vue.common.js"


### PR DESCRIPTION
Corrected a typo in the "cy:open" script. Changed "npx cypres open" to the correct command.